### PR TITLE
scripts: add initial OVSDB contents

### DIFF
--- a/doc/tutorial/tutorial.md
+++ b/doc/tutorial/tutorial.md
@@ -48,11 +48,13 @@ This should create a Nerpa program in `nerpa_controlplane/tutorial`, composed of
 * `tutorial.p4`: P4 program implementing the data plane, that will run on a software switch
 * `tutorial.ovsschema`: OVSDB schema specifying the management plane 
 * `commands.txt`: commands sent to the P4 switch's command-line interface and used to initialize the control plane
+* `init-ovsdb.sh`: transactions for OVSDB's initial contents. These can be commands using `ovsdb-tool` or `ovsdb-client`, with transactions formatted as JSONs as per [RFC 7047](https://www.ietf.org/rfc/rfc7047.txt).
 
 Accordingly, before moving forward, make sure that the following directory structure exists:
 ```
 nerpa_controlplane/tutorial
 | +-- commands.txt
+| +-- init-ovsdb.sh
 | +-- tutorial.dl
 | +-- tutorial.ovsschema
 | +-- tutorial.p4
@@ -61,6 +63,8 @@ nerpa_controlplane/tutorial
 These files should have the following contents.
 
 * `commands.txt` should be empty.
+
+* `init-ovsdb.sh` should be empty.
 
 * `tutorial.dl` should only contain the following comments.
 ```
@@ -232,5 +236,7 @@ Action entry: TutorialIngress.SetVlan - 1,
 ```
 
 Behind the scenes, the OVSDB client processed this new input from OVSDB, converted it to an input relation, and sent it to the running `nerpa_controller`. The controller then used the running DDlog control plane program to compute the output relation. It converted the output into a P4 Runtime table entry and pushed that entry to the switch. Above, that final step is logged.
+
+Note that you could also have copy-pasted those four lines into `nerpa_controlplane/tutorial/init-ovsdb.sh` before calling `run-nerpa`. Then, those rows would have been inserted into OVSDB on start-up. Feel free to stop the currently running script and try this!
 
 Congratulations! You have successfully built, run, and tested VLAN assignment within the Nerpa programming framework.

--- a/nerpa_controlplane/snvs/init-ovsdb.sh
+++ b/nerpa_controlplane/snvs/init-ovsdb.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Running init ovsdb commands!"
+ovsdb-client -v transact tcp:127.0.0.1:6640 '["snvs", {"op": "insert", "table": "Port", "row": {"id": 0, "vlan_mode": "access", "tag": 1, "trunks": 0, "priority_tagging": "no"}}]'
+ovsdb-client -v transact tcp:127.0.0.1:6640 '["snvs", {"op": "insert", "table": "Port", "row": {"id": 1, "vlan_mode": "access", "tag": 1, "trunks": 0, "priority_tagging": "no"}}]'
+ovsdb-client -v transact tcp:127.0.0.1:6640 '["snvs", {"op": "insert", "table": "Port", "row": {"id": 2, "vlan_mode": "access", "tag": 1, "trunks": 0, "priority_tagging": "no"}}]'
+ovsdb-client -v transact tcp:127.0.0.1:6640 '["snvs", {"op": "insert", "table": "Port", "row": {"id": 3, "vlan_mode": "access", "tag": 1, "trunks": 0, "priority_tagging": "no"}}]'

--- a/nerpa_controlplane/snvs/snvs.dl
+++ b/nerpa_controlplane/snvs/snvs.dl
@@ -62,13 +62,6 @@ relation Port(
     priority_tagging: priority_tagging_t
 )
 
-// These are hard-coded for now because we don't have a proper connection to
-// OVSDB yet.
-Port(0, AccessPort{1}, NoPriorityTag).
-Port(1, AccessPort{1}, NoPriorityTag).
-Port(2, AccessPort{1}, NoPriorityTag).
-Port(3, AccessPort{1}, NoPriorityTag).
-
 Port(id, vlan, priority_tagging) :-
     snvs_mp::Port(.id = mp_id, .vlan_mode = mp_vlan_mode, .tag = mp_tag, .trunks = mp_trunks, .priority_tagging = mp_priority_tagging),
     var id = mp_id as port_id_t,

--- a/scripts/create-new-nerpa.sh
+++ b/scripts/create-new-nerpa.sh
@@ -42,3 +42,7 @@ cat <<EOF > $PROGRAM_NAME.ovsschema
     "version": "1.0.0"
 }
 EOF
+
+# Create initial OVSDB contents file.
+touch init-ovsdb.sh
+chmod +x init-ovsdb.sh

--- a/scripts/run-nerpa.sh
+++ b/scripts/run-nerpa.sh
@@ -199,5 +199,12 @@ if test -f "$SCHEMA"; then
     popd >/dev/null
 fi
 
+# If a script with an initial OVSDB command was provided, execute that script in the background.
+INIT_SCRIPT=$FILE_DIR/init-ovsdb.sh
+if test -f "$INIT_SCRIPT"; then
+    echo "Initializing OVSDB contents in background..."
+    $INIT_SCRIPT &
+fi
+
 # Run the controller.
 (cd $NERPA_DIR/nerpa_controller && RUST_BACKTRACE=FULL cargo run -- --ddlog-record=replay.txt $FILE_DIR $FILE_NAME && cd $NERPA_DIR)


### PR DESCRIPTION
This adds a process to add initial OVSDB contents to `run-nerpa.sh`.

It also removes the hard-coded management plane in the `nerpa_controlplane/snvs` program, modifies the tutorial accordingly, and closes #37.