### PR TITLE
scripts: remove unnecessary cargo build calls

### DIFF
--- a/p4info2ddlog/Cargo.lock
+++ b/p4info2ddlog/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "protobuf",
  "protobuf-codegen",
  "rusty-fork",
+ "thiserror",
  "tokio",
 ]
 
@@ -893,6 +894,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/scripts/build-nerpa.sh
+++ b/scripts/build-nerpa.sh
@@ -95,8 +95,7 @@ if test ! -f "$FILE_NAME.dl"; then
 fi
 
 echo "Compiling DDlog crate..."
-ddlog -i $FILE_NAME.dl &&
-(cd ${FILE_NAME}_ddlog && cargo build --release && cd ..)
+ddlog -i $FILE_NAME.dl
 
 # Optionally, generate necessary code for the management plane.
 # Build the OVSDB client crate, which depends on the DDlog crate.
@@ -107,12 +106,12 @@ if test -f $FILE_NAME.ovsschema; then
     cd $NERPA_DIR
     ./scripts/ovsdb-client-toml.sh $1 $2
 
-    # Build the ovsdb client crate.
+    # Generate necessary files for the `ovsdb_client` crate.
+    # This crate is built as part of the `nerpa_controller`.
     cd $NERPA_DIR/ovsdb_client
     mkdir -p src/context
     pip3 install -r requirements.txt
     python3 ovsdb2ddlog2rust --schema-file=$FILE_DIR/$FILE_NAME.ovsschema -p nerpa_ --output-file src/context/nerpa_rels.rs
-    cargo build
     cd $FILE_DIR
 fi
 


### PR DESCRIPTION
This removes several unnecessary calls to `cargo build` in `run-nerpa.sh`. Instead of building the `*_ddlog` and `ovsdb_client` crates individually, this generates all necessary files (through compiling the ddlog program and generating the OVSDB client crate's TOML file) and then builds the `nerpa_controller` crate at the very end.

This makes the build process several minutes faster and is part of #43. It does not close that issue because I think there may be additional ways to accelerate the build.