### PR TITLE
.github: add blank issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -1,0 +1,9 @@
+---
+name: Default
+about: Blank template with no structure.
+title: ''
+labels: ''
+assignees: ''
+
+---
+


### PR DESCRIPTION
The VMware organization has several issue templates that make opening issues a bit harder. This replaces those with a blank issue template and closes #46.