### PR TITLE
p4info2ddlog: fix custom error handling in digests

### DIFF
--- a/p4info2ddlog/src/lib.rs
+++ b/p4info2ddlog/src/lib.rs
@@ -112,7 +112,8 @@ fn extract_p4data_types(
         Some(P4DataTypeSpec::header_stack(ref hs)) => types.push(hs.get_header().get_name().to_owned()),
         Some(P4DataTypeSpec::header_union_stack(ref hus)) => types.push(hus.get_header_union().get_name().to_owned()),
         Some(P4DataTypeSpec::field_enum(ref fe)) => types.push(fe.get_name().to_owned()),
-        Some(P4DataTypeSpec::error(ref e)) => types.push(format!("error when extracting type: {:#?}", e)), // TODO: Find a cleaner method for errors.
+        // Since the Debug trait is implemented for `P4ErrorType`, this should print the name as a String.
+        Some(P4DataTypeSpec::error(ref e)) => types.push(format!("{:#?}", e)),
         Some(P4DataTypeSpec::serializable_enum(ref se)) => types.push(se.get_name().to_owned()),
         Some(P4DataTypeSpec::new_type(ref nt)) => types.push(nt.get_name().to_owned()),
         None => {},


### PR DESCRIPTION
This fixes how `p4info2ddlog` processes error fields within P4 digests.

This change should only improve the correctness of the existing process. Currently, we get the names of all fields in a digest and store them as a set. When we generate custom DDlog types for input relations, we only generate types for P4 structs and types in that set. So, this fix means we should correctly handle custom errors used in digests. Closes #30.