### PR TITLE
Skeleton p4c-of compiler implementation

### DIFF
--- a/ofp4/CMakeLists.txt
+++ b/ofp4/CMakeLists.txt
@@ -1,0 +1,51 @@
+# CMakefile for the OFP4 back-end.
+# To be included in the main P4C compiler CMakefile
+
+message(STATUS "Start configuring OFP4 back end")
+
+# Source files
+set (P4C_OF_SOURCES
+  p4c-of.cpp
+  midend.cpp
+)
+
+# header files
+set (P4C_OF_HEADERS
+  midend.h
+)
+
+set (OF_DIST_HEADERS p4include/of_model.p4)
+
+# Files to check using cpplint
+add_cpplint_files(${CMAKE_CURRENT_SOURCE_DIR} "${P4C_OF_SOURCES};${P4C_OF_HEADERS}")
+
+build_unified(P4C_OF_SOURCES)
+
+add_executable(p4c-of ${P4C_OF_SOURCES})
+target_link_libraries(p4c-of ${P4C_LIBRARIES} ${P4C_LIB_DEPS})
+
+install (TARGETS p4c-of
+  RUNTIME DESTINATION ${P4C_RUNTIME_OUTPUT_DIRECTORY})
+install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/p4include
+  DESTINATION ${P4C_ARTIFACTS_OUTPUT_DIRECTORY})
+
+add_custom_target(linkp4cof
+  COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_BINARY_DIR}/p4c-of ${P4C_BINARY_DIR}/p4c-of
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${P4C_BINARY_DIR}/p4include &&
+          ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${OF_DIST_HEADERS} ${P4C_BINARY_DIR}/p4include
+  COMMAND ${CMAKE_COMMAND} -E create_symlink ${P4C_BINARY_DIR}/p4include ${CMAKE_CURRENT_BINARY_DIR}/p4include
+  )
+
+set (OF_XFAIL_TESTS
+)
+
+add_dependencies(p4c_driver linkp4cof)
+
+# Program used to run tests
+set(OF_DRIVER ${P4C_SOURCE_DIR}/backends/p4test/run-p4-sample.py)
+
+# Tests to run
+set (OF_TEST_SUITES "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.p4")
+p4c_add_tests("of" ${OF_DRIVER} "${OF_TEST_SUITES}" "${OF_XFAIL_TESTS}")
+
+message(STATUS "Done with configuring OFP4 back end")

--- a/ofp4/README.md
+++ b/ofp4/README.md
@@ -1,14 +1,39 @@
-# What is ofp4?
+# Compiling P4 to Open-Flow
 
-ofp4 provides a P4Runtime interface to Open vSwitch.  It accepts
-P4Runtime connections from a controller and connects to an Open
-vSwitch instance over OpenFlow and OVSDB.
+This directory contains a compiler that converts P4 code to Open-Flow.
+The target for this compiler is of_model.p4, which can be found in the
+`p4include` directory.
 
-ofp4 is an experimental prototype.  Currently, the translation from P4
-to OpenFlow is handwritten and has only been done for
+The compiler in fact consumes a P4 program and generates a
+Differential Datalog (DDlog) program
+(https://github.com/vmware/differential-datalog).  The DDlog program
+implements a controller called ofp4, which controls an Open-Flow
+programmable device.
+
+Currently, the translation from P4 to DDlog has been handwritten for
 `nerpa_controlplane/snvs/snvs.p4`.  You can find this handwritten
-translation in `snvs.dl`.  This translation has to be automated by
-writing a p4c backend, but that work hasn't been started yet.
+translation in `snvs.dl`.  Eventually the compiler will generate an
+equivalent form.
+
+## Compiling the p4c-of compiler
+
+To build the P4 compiler with this backend you have to perform the
+following steps:
+
+* Check out the p4c repository from the above address and make sure you can compile the code
+* Create a symbolic link in the directory p4c/extensions pointing to this directory
+* Rebuild the p4c compiler using the standard methodology.
+
+The result of the compilation should be a `p4c-of` binary.
+
+## What is ofp4?
+
+ofp4 is essentially a controller with a P4Runtime interface that
+controls Open vSwitch.  It accepts P4Runtime connections from a
+controller and connects to an Open vSwitch instance over OpenFlow and
+OVSDB.
+
+ofp4 is an experimental prototype.
 
 So far, ofp4 accepts P4Runtime connections and allows multicast groups
 and table entries to be updated, translates those into OpenFlow flows
@@ -30,7 +55,7 @@ Pass `--ofp4` to `scripts/run-nerpa.sh` to make it start up OVS and
 ofp4 instead of bmv2.  This won't pass the tests, since MAC learning
 won't work yet.
 
-# Related Work
+## Related Work
 
 The P4 OpenFlow Agent (https://github.com/p4lang/p4ofagent) provides
 an OpenFlow interface to a P4 switch, the opposite of ofp4.

--- a/ofp4/midend.cpp
+++ b/ofp4/midend.cpp
@@ -1,0 +1,109 @@
+/*
+Copyright 2022 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "frontends/common/constantFolding.h"
+#include "frontends/common/resolveReferences/resolveReferences.h"
+#include "frontends/p4/evaluator/evaluator.h"
+#include "frontends/p4/fromv1.0/v1model.h"
+#include "frontends/p4/moveDeclarations.h"
+#include "frontends/p4/simplify.h"
+#include "frontends/p4/strengthReduction.h"
+#include "frontends/p4/toP4/toP4.h"
+#include "frontends/p4/typeMap.h"
+#include "frontends/p4/unusedDeclarations.h"
+#include "midend.h"
+#include "midend/actionSynthesis.h"
+#include "midend/compileTimeOps.h"
+#include "midend/complexComparison.h"
+#include "midend/copyStructures.h"
+#include "midend/eliminateTuples.h"
+#include "midend/eliminateNewtype.h"
+#include "midend/eliminateSerEnums.h"
+#include "midend/eliminateSwitch.h"
+#include "midend/flattenHeaders.h"
+#include "midend/flattenInterfaceStructs.h"
+#include "midend/hsIndexSimplify.h"
+#include "midend/expandEmit.h"
+#include "midend/expandLookahead.h"
+#include "midend/global_copyprop.h"
+#include "midend/local_copyprop.h"
+#include "midend/midEndLast.h"
+#include "midend/nestedStructs.h"
+#include "midend/noMatch.h"
+#include "midend/predication.h"
+#include "midend/removeExits.h"
+#include "midend/removeMiss.h"
+#include "midend/simplifyKey.h"
+#include "midend/tableHit.h"
+#include "midend/removeAssertAssume.h"
+
+namespace P4OF {
+
+MidEnd::MidEnd(CompilerOptions& options) {
+    bool isv1 = options.langVersion == CompilerOptions::FrontendVersion::P4_14;
+    refMap.setIsV1(isv1);
+    auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
+    setName("MidEnd");
+
+    addPasses({
+        options.ndebug ? new P4::RemoveAssertAssume(&refMap, &typeMap) : nullptr,
+        new P4::RemoveMiss(&refMap, &typeMap),
+        new P4::EliminateNewtype(&refMap, &typeMap),
+        new P4::EliminateSerEnums(&refMap, &typeMap),
+        new P4::SimplifyKey(&refMap, &typeMap,
+                            new P4::OrPolicy(
+                                new P4::IsValid(&refMap, &typeMap),
+                                new P4::IsLikeLeftValue())),
+        new P4::RemoveExits(&refMap, &typeMap),
+        new P4::ConstantFolding(&refMap, &typeMap),
+        new P4::ExpandLookahead(&refMap, &typeMap),
+        new P4::ExpandEmit(&refMap, &typeMap),
+        new P4::HandleNoMatch(&refMap),
+        new P4::StrengthReduction(&refMap, &typeMap),
+        new P4::EliminateTuples(&refMap, &typeMap),
+        new P4::SimplifyComparisons(&refMap, &typeMap),
+        new P4::CopyStructures(&refMap, &typeMap, false),
+        new P4::NestedStructs(&refMap, &typeMap),
+        new P4::FlattenHeaders(&refMap, &typeMap),
+        new P4::FlattenInterfaceStructs(&refMap, &typeMap),
+        new P4::Predication(&refMap),
+        new P4::MoveDeclarations(),  // more may have been introduced
+        new P4::ConstantFolding(&refMap, &typeMap),
+        new P4::GlobalCopyPropagation(&refMap, &typeMap),
+        new PassRepeated({
+            new P4::LocalCopyPropagation(&refMap, &typeMap),
+            new P4::ConstantFolding(&refMap, &typeMap),
+        }),
+        new P4::StrengthReduction(&refMap, &typeMap),
+        new P4::MoveDeclarations(),  // more may have been introduced
+        new P4::SimplifyControlFlow(&refMap, &typeMap),
+        new P4::CompileTimeOperations(),
+        new P4::TableHit(&refMap, &typeMap),
+        new P4::EliminateSwitch(&refMap, &typeMap),
+        evaluator,
+        new P4::HSIndexSimplifier(&refMap, &typeMap),
+        new P4::SynthesizeActions(&refMap, &typeMap),
+        new P4::MoveActionsToTables(&refMap, &typeMap),
+        evaluator,
+        [this, evaluator]() { toplevel = evaluator->getToplevelBlock(); },
+        new P4::MidEndLast()
+    });
+    if (options.excludeMidendPasses) {
+        removePasses(options.passesToExcludeMidend);
+    }
+}
+
+}  // namespace P4OF

--- a/ofp4/midend.h
+++ b/ofp4/midend.h
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _EXTENSIONS_OFP4_MIDEND_H_
+#define _EXTENSIONS_OFP4_MIDEND_H_
+
+#include "ir/ir.h"
+#include "frontends/common/options.h"
+#include "frontends/p4/evaluator/evaluator.h"
+
+namespace P4OF {
+
+class MidEnd : public PassManager {
+ public:
+    P4::ReferenceMap    refMap;
+    P4::TypeMap         typeMap;
+    IR::ToplevelBlock   *toplevel = nullptr;
+
+    explicit MidEnd(CompilerOptions& options);
+    IR::ToplevelBlock* process(const IR::P4Program *&program) {
+        program = program->apply(*this);
+        return toplevel; }
+};
+
+}   // namespace P4OF
+
+#endif /* _EXTENSIONS_OFP4_MIDEND_H_ */

--- a/ofp4/p4c-of.cpp
+++ b/ofp4/p4c-of.cpp
@@ -1,0 +1,108 @@
+/*
+Copyright 2022 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// Entry point for p4c-of compiler: compiler generating code for open-flow
+
+#include <fstream>
+#include <iostream>
+
+#include "control-plane/p4RuntimeSerializer.h"
+#include "ir/ir.h"
+#include "ir/json_loader.h"
+#include "lib/log.h"
+#include "lib/error.h"
+#include "lib/exceptions.h"
+#include "lib/gc.h"
+#include "lib/crash.h"
+#include "lib/nullstream.h"
+#include "frontends/common/applyOptionsPragmas.h"
+#include "frontends/common/parseInput.h"
+#include "frontends/p4/evaluator/evaluator.h"
+#include "frontends/p4/frontend.h"
+#include "frontends/p4/toP4/toP4.h"
+#include "midend.h"
+
+class P4OFOptions : public CompilerOptions {
+ public:
+    bool loadIRFromJson = false;
+    P4OFOptions() {
+        registerOption("--fromJSON", "file",
+                       [this](const char* arg) {
+                           loadIRFromJson = true;
+                           file = arg;
+                           return true;
+                       },
+                       "read previously dumped json instead of P4 source code");
+     }
+};
+
+using P4OFContext = P4CContextWithOptions<P4OFOptions>;
+
+int main(int argc, char *const argv[]) {
+    setup_gc_logging();
+    setup_signals();
+
+    AutoCompileContext autoP4TestContext(new P4OFContext);
+    auto& options = P4OFContext::get().options();
+    options.langVersion = CompilerOptions::FrontendVersion::P4_16;
+    options.compilerVersion = "0.1";
+
+    if (options.process(argc, argv) != nullptr) {
+        if (options.loadIRFromJson == false)
+            options.setInputFile();
+    }
+    if (::errorCount() > 0)
+        return 1;
+    const IR::P4Program *program = nullptr;
+    auto hook = options.getDebugHook();
+    if (options.loadIRFromJson) {
+        std::ifstream json(options.file);
+        if (json) {
+            JSONLoader loader(json);
+            const IR::Node* node = nullptr;
+            loader >> node;
+            if (!(program = node->to<IR::P4Program>()))
+                error(ErrorType::ERR_INVALID, "%s is not a P4Program in json format", options.file);
+        } else {
+            error(ErrorType::ERR_IO, "Can't open %s", options.file); }
+    } else {
+        program = P4::parseP4File(options);
+
+        if (program != nullptr && ::errorCount() == 0) {
+            P4::P4COptionPragmaParser optionsPragmaParser;
+            program->apply(P4::ApplyOptionsPragmas(optionsPragmaParser));
+
+            P4::FrontEnd fe;
+            fe.addDebugHook(hook);
+            program = fe.run(options, program);
+        }
+    }
+
+    if (program != nullptr && ::errorCount() == 0) {
+        P4::serializeP4RuntimeIfRequired(program, options);
+        P4OF::MidEnd midEnd(options);
+        midEnd.addDebugHook(hook);
+        midEnd.process(program);
+        if (program) {
+            if (options.dumpJsonFile)
+                JSONGenerator(*openFile(options.dumpJsonFile, true), true) << program << std::endl;
+        }
+    }
+
+    if (Log::verbose())
+        std::cerr << "Done." << std::endl;
+    return ::errorCount() > 0;
+}

--- a/ofp4/p4include/of_model.p4
+++ b/ofp4/p4include/of_model.p4
@@ -52,21 +52,11 @@ match_kind {
     optional
 }
 
-/* Metadata fields.  These are always present for every packet. */
-struct Metadata {
-    PortID in_port;             /* Ingress port. */
-    bit<32> skb_priority;       /* Linux packet scheduling class. */
-    bit<32> pkt_mark;           /* Linux kernel metadata. */
-    bit<32> packet_type;        /* OpenFlow packet type.  0 for Ethernet. */
-    Tunnel tunnel;
-    Conntrack ct;
-}
-
 /* Tunnel metadata.  These are all-zero for packets that did not arrive in
  * a tunnel. */
 struct Tunnel {
     bit<64> tun_id;             /* VXLAN VNI, GRE key, Geneve VNI, ... */
-    bit<32> tun_src;		/* Outer IPv4 source address. */
+    bit<32> tun_src;            /* Outer IPv4 source address. */
     bit<32> tun_dst;            /* Outer IPv4 destination address. */
     bit<128> tun_ipv6_src;      /* Outer IPv6 source address. */
     bit<128> tun_ipv6_dst;      /* Outer IPv6 destination address. */
@@ -77,7 +67,7 @@ struct Tunnel {
     bit<8> tun_erspan_dir;      /* ERSPAN direction (low bit only). */
     bit<8> tun_erspan_hwid;     /* ERSPAN ERSPAN engine ID (low 6 bits). */
     bit<8> tun_gtpu_flags;      /* GTP-U flags. */
-    bit<8> tun_gtpu_msgtype;	/* GTP-U message type. */
+    bit<8> tun_gtpu_msgtype;    /* GTP-U message type. */
     bit<16> tun_flags;          /* Tunnel flags (low bit only). */
 
     /* Access to Geneve tunneling TLV options. */
@@ -102,9 +92,9 @@ const bit<32> CS_DNAT = 1 << 7; // 1 if packet awas already DNATed.
  * them.
  */
 struct Conntrack {
-    bit<32> ct_state;		// CS_*.
+    bit<32> ct_state;           // CS_*.
     bit<16> ct_zone;            // Connection-tracking zone.
-    bit<32> ct_mark;		// Arbitrary metadata.
+    bit<32> ct_mark;            // Arbitrary metadata.
     bit<128> ct_label;          // More arbitrary metadata.
 
     /* The following fields require a match to a valid connection tracking state
@@ -120,6 +110,16 @@ struct Conntrack {
     bit<16> ct_tp_dst;
 }
 
+/* Metadata fields.  These are always present for every packet. */
+struct Metadata {
+    PortID in_port;             /* Ingress port. */
+    bit<32> skb_priority;       /* Linux packet scheduling class. */
+    bit<32> pkt_mark;           /* Linux kernel metadata. */
+    bit<32> packet_type;        /* OpenFlow packet type.  0 for Ethernet. */
+    Tunnel tunnel;
+    Conntrack ct;
+}
+
 header Ethernet {
     bit<48> src;
     bit<48> dst;
@@ -133,13 +133,13 @@ header Vlan {
 }
 
 header Mpls {
-    bit<32> label;		// Label (low 20 bits).
-    bit<8> tc;			// Traffic class (low 3 bits).
-    bit<8> bos;			// Bottom of Stack (low bit only).
-    bit<8> ttl			// Time to live.
+    bit<32> label;              // Label (low 20 bits).
+    bit<8> tc;                  // Traffic class (low 3 bits).
+    bit<8> bos;                 // Bottom of Stack (low bit only).
+    bit<8> ttl;                 // Time to live.
 }
 
-const bit<8> FRAG_ANY = 1 << 0;	  // Set for any IP fragment.
+const bit<8> FRAG_ANY = 1 << 0;   // Set for any IP fragment.
 const bit<8> FRAG_LATER = 1 << 1; // Set for IP fragment with nonzero offset.
 
 header Ipv4 {
@@ -147,7 +147,7 @@ header Ipv4 {
     bit<32> dst;
     bit<8> proto;
     bit<8> ttl;
-    bit<8> frag;		// 0, or FRAG_ANY, or (FRAG_ANY | FRAG_LATER)
+    bit<8> frag;                // 0, or FRAG_ANY, or (FRAG_ANY | FRAG_LATER)
     bit<8> tos;                 // DSCP in top 6 bits, ECN in low 2 bits.
 }
 
@@ -156,7 +156,7 @@ header Ipv6 {
     bit<128> dst;
     bit<8> proto;
     bit<8> ttl;
-    bit<8> frag;		// 0, or FRAG_ANY, or (FRAG_ANY | FRAG_LATER)
+    bit<8> frag;                // 0, or FRAG_ANY, or (FRAG_ANY | FRAG_LATER)
     bit<8> tos;                 // DSCP in top 6 bits, ECN in low 2 bits.
 }
 
@@ -174,7 +174,7 @@ header Nsh {
     bit<8> ttl;
     bit<8> mdtype;
     bit<8> np;
-    bit<32> spi; 		// Low 24 bits only.
+    bit<32> spi;                // Low 24 bits only.
     bit<8> si;
     bit<32> c1;
     bit<32> c2;
@@ -185,7 +185,7 @@ header Nsh {
 struct Tcp {
     bit<16> src;
     bit<16> dst;
-    bit<16> flags;		// Low 12 bits only.
+    bit<16> flags;              // Low 12 bits only.
 }
 
 struct Udp {


### PR DESCRIPTION
Most of the code is stolen from the p4test compiler.
There is yet no backend, but the compiler is good enough to validate of_model.p4.