### PR TITLE
Update to tokio 1.8.4+ to avoid race conditions.

### DIFF
--- a/p4ext/Cargo.toml
+++ b/p4ext/Cargo.toml
@@ -17,7 +17,7 @@ proto = {path = "../proto"}
 protobuf = "2.22.0"
 protobuf-codegen = "2.22.0"
 rusty-fork = "0.3.0"
-tokio = { version = "1.2.0", features = ["full"] }
+tokio = { version = "1.8.4", features = ["full"] }
 thiserror = "1.0"
 
 # differential_datalog is a generic library that doesn't vary from one

--- a/p4info2ddlog/Cargo.lock
+++ b/p4info2ddlog/Cargo.lock
@@ -918,11 +918,10 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.6.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
- "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -938,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.2.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
tokio before version 1.8.4 has a few race conditions reported by
dependabot, e.g. https://github.com/vmware/nerpa/security/dependabot/9.
By upgrading, we avoid the problem.