### PR TITLE
scripts: remove installation of simple_switch_grpc

### DIFF
--- a/scripts/install-nerpa.sh
+++ b/scripts/install-nerpa.sh
@@ -38,7 +38,6 @@ CONFIGURE="./configure --prefix=$NERPA_DEPS/inst CPPFLAGS=-I$NERPA_DEPS/inst/inc
 echo "Configuring behavioral model..."
 (cd behavioral-model && autogen.sh && $CONFIGURE --with-pi)
 (cd behavioral-model && make install)
-(cd behavioral-model/targets/simple_switch_grpc/ && ./autogen.sh && $CONFIGURE && make install)
 
 # Configure the p4c compiler.
 echo "Configuring p4c..."


### PR DESCRIPTION
In the latest version of behavioral-model, the simple_switch_grpc
is compiled when the behavioral-model is compiled with the
`--with-pi` flag. Additional files for compiling the simple switch,
like `targets/simple_switch_grpc/autogen.sh` have been removed.
This updates the installation script accordingly. Closes #64.