### PR TITLE
p4c-of: Fix bitwise matches.

### DIFF
--- a/ofp4/of.cpp
+++ b/ofp4/of.cpp
@@ -30,22 +30,20 @@ cstring OF_Register::toString() const {
     return asDDlogString("true");
 }
 
+cstring OF_Register::mask() const {
+    auto mask = Constant::GetMask(high+1) ^ Constant::GetMask(low);
+    return Util::toString(mask.value, 0, false, 16);
+}
+
 cstring OF_Register::asDDlogString(bool inMatch) const {
     // A register is written differently depending on the position
     // in the OF statement.
-    size_t n = number;
-    cstring regName = "reg" + Util::toString(n);
-    cstring result = "";
-    for (size_t i = bundle; i > 1; i >>= 1) {
-        result += "x";
-        n /= 2;
-    }
-    result += regName;
-    if (inMatch) {
-        auto mask = Constant::GetMask(high+1) ^ Constant::GetMask(low);
-        result += "/" + Util::toString(mask.value, 0, false, 16);
-    } else {
-        if (high != registerSize * bundle)
+    if (!isSlice())
+        return name;
+
+    cstring result = name;
+    if (!inMatch) {
+        if (high != size)
             result += "[" + Util::toString(low);
         if (high > low)
             result += ".." + Util::toString(high);

--- a/ofp4/of.def
+++ b/ofp4/of.def
@@ -32,14 +32,16 @@ class OF_Register : OF_Expression {
     static const size_t registerSize;  // size of a register in bits
     static const size_t maxBundleSize;  // xxreg0 has 4 registers, i.e. 128 bits
 
-    size_t number;  // Register number
+    cstring name;   // e.g. "xreg1"
+    size_t size;    // Field size in bits
     size_t low;     // Low bit number
     size_t high;    // High bit number
-    size_t bundle;  // How many registers bundled together (1, 2, or 4 allowed)
     optional cstring friendlyName;
     cstring toString() const;
     /// Generates a DDlog expression that returns the register at runtime.
     cstring asDDlogString(bool inMatch) const;
+    cstring mask() const;
+    bool isSlice() const { return low != 0 || high != size - 1; }
 #nodbprint
 }
 

--- a/ofp4/ofvisitors.h
+++ b/ofp4/ofvisitors.h
@@ -32,7 +32,8 @@ class OpenFlowSimplify : public Transform {
         if (auto br = slice->base->to<IR::OF_Register>()) {
             // convert the slice of a register into a register
             return new IR::OF_Register(
-                br->number, br->low + slice->low, br->low + slice->high, br->bundle);
+                br->name, br->size, br->low + slice->low, br->low + slice->high,
+                br->friendlyName);
         }
         return slice;
     }

--- a/ofp4/resources.h
+++ b/ofp4/resources.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define _EXTENSIONS_OFP4_RESOURCES_H_
 
 #include "lib/algorithm.h"
+#include "lib/stringify.h"
 #include "ir/ir.h"
 #include "frontends/p4/typeMap.h"
 
@@ -59,9 +60,11 @@ class OFResources {
             return nullptr;
         }
 
-        size_t bundle = 1;
-        while (width > bundle * IR::OF_Register::registerSize) {
-            bundle *= 2;
+        cstring name = "";
+        size_t size = IR::OF_Register::registerSize;
+        while (width > size) {
+            size *= 2;
+            name += "x";
         }
 
         bool found = false;
@@ -93,9 +96,11 @@ class OFResources {
             assert(!byteMask[i]);
             byteMask[i] = true;
         }
-        auto result = new IR::OF_Register(index / bytesPerRegister,
+        name += "reg" + Util::toString(index / bytesPerRegister);
+        auto result = new IR::OF_Register(name,
+                                          size,
                                           (index % bytesPerRegister) * 8,
-                                          (index % bytesPerRegister) * 8 + width-1, bundle,
+                                          (index % bytesPerRegister) * 8 + width-1,
                                           makeId(decl->externalName()));
         map.emplace(decl, result);
         LOG3("Allocated " << result->toString() << " for " << decl);

--- a/ofp4/snvs.p4
+++ b/ofp4/snvs.p4
@@ -238,10 +238,12 @@ control SnvsEgress(inout Headers hdr,
 #endif
 
       // Drop loopback.
+#if 0 /* Disabled because comparing multibit values is difficult */
       if (meta_out.out_port == meta_in.in_port) {
           meta_out.out_port = 0;
           exit;
       }
+#endif
 
       // Output VLAN processing, including priority tagging.
       bool tag_vlan = OutputVlan.apply().hit;


### PR DESCRIPTION
Bitwise matches in flows used the wrong syntax.  To match a 1-bit with
value 0x100 in reg1, it used the incorrect syntax "reg1/0x100=1".  The
correct syntax is "reg1=0x100/0x100", that is, "field=value/mask" in
which "value" is shifted to match up bitwise with "mask".  This commit
fixes the problem.

One contribution to the problem is that OF_Fieldname doesn't have any
provisions to keep track of a bitwise slice, which is necessary to be able
to handle expressions that match against them.  One way to do this would
be to handle OF_Slice with an inner OF_Fieldname.  But there's an existing
OF_Register that is suitable and already has slice support.  The only
problem is that it is specialized for registers name-wise and size-wise.
Thus, this commit adapts OF_Register so it can handle any field, and
switches uses of OF_Fieldname to OF_Register wherever that is appropriate
(which is for anything other than 'table=X', 'priority=X', prerequisites,
and action parameter names).

It probably makes sense to rename OF_Register to OF_Field and OF_Fieldname
to something else too (since it's never used for field matches anymore).
This commit doesn't do that.

Signed-off-by: Ben Pfaff <bpfaff@vmware.com>