### PR TITLE
p4c-of: Fix types in emitted expressions.

### DIFF
--- a/ofp4/ofvisitors.cpp
+++ b/ofp4/ofvisitors.cpp
@@ -128,11 +128,13 @@ static void printRegisterMatch(std::vector<const IR::OF_EqualsMatch*>& erms,
             if (erm->right->to<IR::OF_Constant>()) {
                 ofp.visit(erm->right);
             } else if (auto value = erm->right->to<IR::OF_InterpolatedVarExpression>()) {
-                if (reg->is_boolean)
-                    buffer += "(if (";
-                buffer += value->varname;
-                if (reg->is_boolean)
-                    buffer += ") 1 else 0)";
+                if (!reg->is_boolean) {
+                    buffer += value->varname;
+                    if (erms.size() > 1 || reg->low > 0)
+                        buffer += " as bit<" + Util::toString(reg->size) + ">";
+                } else {
+                    buffer += "(if (" + value->varname + ") 1 else 0)";
+                }
             } else {
                 BUG("%1%: don't know how to shift left for matching", erm->toString());
             }


### PR DESCRIPTION
Some expressions emitted by p4c-of had type errors.  For some of these,
the compiler reported the problem, e.g. for
    ${(has_vlan << 12) | vid}
where 'vid' is bit<12> and 'has_vlan' is bit<1>.  This commit corrects
those problems by inserting casts to the type of the containing
register, e.g.:
    ${(has_vlan as bit<16> << 12) | vid as bit<16>}

This commit also corrects bugs that were not compiler errors.  Given 12-bit
'vlan', for example, the compiler previously emitted this in one case:
    ${r_vlan(true)}=${vlan << 8}/0xfff00
However, shifting bit<12> left by 8 bits loses bits, which isn't the
intention.  This commit fixes that by instead emitting:
    ${r_vlan(true)}=${vlan as bit<32> << 8}/0xfff00

It's possible to fix this with a smaller patch, but I found that separating
the boolean and non-boolean cases made the code easier to read.

Signed-off-by: Ben Pfaff <bpfaff@vmware.com>